### PR TITLE
Update activerecord_settings.rb

### DIFF
--- a/lib/activerecord_settings.rb
+++ b/lib/activerecord_settings.rb
@@ -29,7 +29,7 @@ module ActiverecordSettings
       existing = find_by_key(key)
 
       if existing
-        existing.update_attributes(setting)
+        existing.update(setting)
       else
         create({ key: key }.merge(setting))
       end


### PR DESCRIPTION
Replace #update_attributes with #update as #update_attributes is deprecated in Rails 6