### PR TITLE
fix: Ensure ActiveRecord permitted classes settings are respected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -46,9 +47,14 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     minitest (5.14.4)
-    nokogiri (1.11.5-x86_64-darwin)
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
     power_assert (2.0.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -88,12 +94,15 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-19
 
 DEPENDENCIES
   activerecord_settings!
   bundler (>= 2.1.0)
   generator_spec (~> 0)
+  pry (~> 0.14.1)
   rake (~> 13.0)
   rspec (~> 3.0)
   sqlite3 (~> 1.0)
@@ -101,4 +110,4 @@ DEPENDENCIES
   timecop (~> 0.9)
 
 BUNDLED WITH
-   2.2.17
+   2.4.12

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Or install it yourself as:
 Create the migration to create the activerecord table with
 
     bundle exec rails g activerecord_settings:install
+
+As this library uses YAML to serialize/deserialize the values, in recent versions of Rails, you will need to add your list of permitted classes to your `config/application.rb` file:
+
+    config.active_record.yaml_column_permitted_classes = [
+      Symbol,
+      ActiveSupport::TimeWithZone,
+      ActiveSupport::TimeZone
+    ]
     
 Then you can set and get values like this
 

--- a/activerecord_settings.gemspec
+++ b/activerecord_settings.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_development_dependency "generator_spec", "~> 0"
   spec.add_development_dependency "timecop", "~> 0.9"
+  spec.add_development_dependency "pry", "~> 0.14.1"
 end

--- a/lib/activerecord_settings.rb
+++ b/lib/activerecord_settings.rb
@@ -23,7 +23,7 @@ module ActiverecordSettings
       if ActiveRecord.try(:use_yaml_unsafe_load) && YAML.respond_to?(:unsafe_load)
         YAML.unsafe_load(setting.value)
       elsif ActiveRecord.respond_to?(:yaml_column_permitted_classes)
-        YAML.safe_load(setting.value, permitted_classes: ActiveRecord.yaml_column_permitted_classes)
+        YAML.safe_load(setting.value, permitted_classes: ActiveRecord.yaml_column_permitted_classes, aliases: true)
       else
         YAML.load(setting.value)
       end

--- a/spec/activerecord_settings_spec.rb
+++ b/spec/activerecord_settings_spec.rb
@@ -7,21 +7,6 @@ RSpec.describe ActiverecordSettings do
     expect(ActiverecordSettings::VERSION).not_to be nil
   end
 
-  it "Can set/get a numeric key" do
-    ActiverecordSettings::Setting.set('key', test_number)
-    expect(ActiverecordSettings::Setting.get('key')).to eq test_number
-  end
-
-  it "Can set/get a string key" do
-    ActiverecordSettings::Setting.set('key', test_string)
-    expect(ActiverecordSettings::Setting.get('key')).to eq test_string
-  end
-
-  it "Can set/get an object key" do
-    ActiverecordSettings::Setting.set('key', test_object)
-    expect(ActiverecordSettings::Setting.get('key')).to eq test_object
-  end
-
   it "Can destroy a key" do
     ActiverecordSettings::Setting.set('key', test_object)
     expect(ActiverecordSettings::Setting.get('key')).to eq test_object
@@ -35,6 +20,89 @@ RSpec.describe ActiverecordSettings do
 
     Timecop.freeze(Date.today + 2) do
       expect(ActiverecordSettings::Setting.get('key')).to eq nil
+    end
+  end
+
+  context 'When default classes are used' do
+    it "Can set/get a numeric key" do
+      ActiverecordSettings::Setting.set('key', test_number)
+      expect(ActiverecordSettings::Setting.get('key')).to eq test_number
+    end
+
+    it "Can set/get a string key" do
+      ActiverecordSettings::Setting.set('key', test_string)
+      expect(ActiverecordSettings::Setting.get('key')).to eq test_string
+    end
+
+    it "Can set/get a hash key" do
+      ActiverecordSettings::Setting.set('key', test_object)
+      expect(ActiverecordSettings::Setting.get('key')).to eq test_object
+    end
+  end
+
+  describe 'When running ruby less than 3.1', if: Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('3.1') do
+    let!(:datetime_object) { DateTime.now }
+
+    context 'It allows unsafe yaml loading' do
+      it 'can set/get a DateTime key' do
+        ActiverecordSettings::Setting.set('key', datetime_object)
+        expect(ActiverecordSettings::Setting.get('key')).to eq datetime_object
+      end
+    end
+  end
+
+  describe 'When running ruby 3.1+', if: Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1') do
+    context 'When non permitted classes are used' do
+      it 'Raises a Psych::DisallowedClass error' do
+        time = DateTime.now
+        ActiverecordSettings::Setting.set('key', time)
+
+        expect {
+          ActiverecordSettings::Setting.get('key')
+        }.to raise_error(Psych::DisallowedClass)
+      end
+    end
+
+    context 'When active record has a permitted classes setting' do
+      let!(:datetime_object) { DateTime.now }
+
+      before do
+        allow(ActiveRecord).to receive(:yaml_column_permitted_classes).and_return([DateTime, Time])
+      end
+
+      it 'Does not raise a Psych::DisallowedClass error' do
+        ActiverecordSettings::Setting.set('key', datetime_object)
+
+        expect {
+          ActiverecordSettings::Setting.get('key')
+        }.to_not raise_error
+      end
+
+      it 'can set/get a DateTime key' do
+        ActiverecordSettings::Setting.set('key', datetime_object)
+        expect(ActiverecordSettings::Setting.get('key')).to eq datetime_object
+      end
+    end
+
+    context 'When active record has a use_yaml_unsafe_load setting' do
+      let!(:datetime_object) { DateTime.now }
+
+      before do
+        allow(ActiveRecord).to receive(:use_yaml_unsafe_load).and_return(true)
+      end
+
+      it 'Does not raise an error' do
+        ActiverecordSettings::Setting.set('key', datetime_object)
+
+        expect {
+          ActiverecordSettings::Setting.get('key')
+        }.to_not raise_error
+      end
+
+      it 'can set/get a DateTime key' do
+        ActiverecordSettings::Setting.set('key', datetime_object)
+        expect(ActiverecordSettings::Setting.get('key')).to eq datetime_object
+      end
     end
   end
 end

--- a/spec/activerecord_settings_spec.rb
+++ b/spec/activerecord_settings_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ActiverecordSettings do
     end
   end
 
-  describe 'When running ruby less than 3.1', if: Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('3.1') do
+  describe 'When running ruby less than 3.1', if: Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1') do
     let!(:datetime_object) { DateTime.now }
 
     context 'It allows unsafe yaml loading' do


### PR DESCRIPTION
Description:
* Fix for https://github.com/dansingerman/activerecord_settings/issues/42
* Should be backward compatible with previously supported ruby/active record versions
* Tested using Ruby 3.3.0 and Rails 7
 

